### PR TITLE
Update instructions for Trixie only

### DIFF
--- a/debian-13-trixie/ignore.d.server/dhclient
+++ b/debian-13-trixie/ignore.d.server/dhclient
@@ -1,0 +1,3 @@
+dhclient\[[0-9]+\]: PRC: Renewing lease on .*\.$
+dhclient\[[0-9]+\]: XMT: Renew on .*, interval [0-9]+ms\.$
+dhclient\[[0-9]+\]: RCV: Reply message on .* from .*\.$

--- a/debian-13-trixie/ignore.d.server/dhclient
+++ b/debian-13-trixie/ignore.d.server/dhclient
@@ -1,3 +1,3 @@
-dhclient\[[0-9]+\]: PRC: Renewing lease on .*\.$
-dhclient\[[0-9]+\]: XMT: Renew on .*, interval [0-9]+ms\.$
-dhclient\[[0-9]+\]: RCV: Reply message on .* from .*\.$
+dhclient\[[0-9]+\]: PRC: Renewing lease on .*$
+dhclient\[[0-9]+\]: XMT: Renew on .*, interval .*$
+dhclient\[[0-9]+\]: RCV: Reply message on .* from .*$

--- a/debian-13-trixie/test/dhclient
+++ b/debian-13-trixie/test/dhclient
@@ -1,0 +1,6 @@
+Dec 20 13:16:48 wopr dhclient[1]: PRC: Renewing lease on eth0.
+Dec 20 13:16:48 wopr dhclient[1]: XMT: Renew on eth0, interval 9820ms.
+Dec 20 13:16:48 wopr dhclient[1]: RCV: Reply message on eth0 from fe80::20d:b9ff:fe61:af81.
+Dec 20 13:46:54 wopr dhclient[1]: PRC: Renewing lease on eth0.
+Dec 20 13:46:54 wopr dhclient[1]: XMT: Renew on eth0, interval 9940ms.
+Dec 20 13:46:55 wopr dhclient[1]: RCV: Reply message on eth0 from fe80::20d:b9ff:fe61:af81.

--- a/debian-13-trixie/test/dhclient
+++ b/debian-13-trixie/test/dhclient
@@ -1,6 +1,6 @@
 Dec 20 13:16:48 wopr dhclient[1]: PRC: Renewing lease on eth0.
 Dec 20 13:16:48 wopr dhclient[1]: XMT: Renew on eth0, interval 9820ms.
-Dec 20 13:16:48 wopr dhclient[1]: RCV: Reply message on eth0 from fe80::20d:b9ff:fe61:af81.
+Dec 20 13:16:48 wopr dhclient[1]: RCV: Reply message on eth0 from fe80::20d:c9fa:ae62:ff81.
 Dec 20 13:46:54 wopr dhclient[1]: PRC: Renewing lease on eth0.
 Dec 20 13:46:54 wopr dhclient[1]: XMT: Renew on eth0, interval 9940ms.
-Dec 20 13:46:55 wopr dhclient[1]: RCV: Reply message on eth0 from fe80::20d:b9ff:fe61:af81.
+Dec 20 13:46:55 wopr dhclient[1]: RCV: Reply message on eth0 from fe80::20d:c9fa:ae62:ff81.


### PR DESCRIPTION
- Added testcases for dhclient lease renewal messages
- Created filter rules to ignore PRC, XMT, and RCV messages
- Testcases use wopr as hostname and pid 1